### PR TITLE
I would like to gracefully close the sockets in m2node.

### DIFF
--- a/lib/m2node.js
+++ b/lib/m2node.js
@@ -6,7 +6,7 @@
   exports.run = function(server, options) {
     var handler;
     handler = new Handler(options);
-    return handler.on('request', function(request) {
+    handler.on('request', function(request) {
       var fakeSocket;
       fakeSocket = new FakeSocket();
       fakeSocket.on('write', function() {
@@ -15,5 +15,6 @@
       server.emit('connection', fakeSocket);
       return fakeSocket.emitData(request.toFullHttpRequest());
     });
+    return handler;
   };
 }).call(this);

--- a/lib/m2node/fake_socket.js
+++ b/lib/m2node/fake_socket.js
@@ -30,6 +30,7 @@
     FakeSocket.prototype.setTimeout = function(timeout, callback) {};
     FakeSocket.prototype.write = function(data) {
       var combinedBuffer;
+      data = new Buffer(data.toString());
       combinedBuffer = new Buffer(this.writeBuffer.length + data.length);
       this.writeBuffer.copy(combinedBuffer);
       combinedBuffer.write(data.toString(), this.writeBuffer.length);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "keywords"            : ["http", "mongrel2"],
   "homepage"            : "https://github.com/dan-manges/m2node",
   "author"              : "Dan Manges <dan.manges@gmail.com> (http://www.dan-manges.com)",
+  "contributors" :
+    [ "Paul Bergeron <paul.d.bergeron@gmail.com>" ],
   "main"                : "./lib/m2node.js",
   "repository"          : { "type": "git", "url" : "https://github.com/dan-manges/m2node.git" },
   "engines"             : { "node": "~0.4.8" },

--- a/src/m2node.coffee
+++ b/src/m2node.coffee
@@ -11,4 +11,5 @@ exports.run = (server, options) ->
       handler.sendResponse(request, fakeSocket.writeBuffer)
     server.emit 'connection', fakeSocket
     fakeSocket.emitData(request.toFullHttpRequest())
+  handler
 

--- a/src/m2node/fake_socket.coffee
+++ b/src/m2node/fake_socket.coffee
@@ -19,6 +19,7 @@ class FakeSocket extends events.EventEmitter
   setTimeout: (timeout, callback) -> # noop
 
   write: (data) ->
+    data = new Buffer data.toString()
     combinedBuffer = new Buffer(@writeBuffer.length + data.length)
     @writeBuffer.copy(combinedBuffer)
     combinedBuffer.write(data.toString(), @writeBuffer.length)


### PR DESCRIPTION
m2node.run() now returns the handler it creates. This is so that later the sockets can be closed gracefully with:

```
handler.pullSocket.close();
handler.pubSocket.close();
```

If you think there is a better way to handle this, please let me know and I'll make the needed changes.
