### PR TITLE
Emit ZMQ errors when they occur

### DIFF
--- a/lib/m2node.js
+++ b/lib/m2node.js
@@ -10,7 +10,8 @@
       var fakeSocket;
       fakeSocket = new FakeSocket();
       fakeSocket.on('write', function() {
-        return handler.sendResponse(request, fakeSocket.writeBuffer);
+        handler.sendResponse(request, fakeSocket.writeBuffer);
+        return handler.emit('response');
       });
       server.emit('connection', fakeSocket);
       return fakeSocket.emitData(request.toFullHttpRequest());

--- a/lib/m2node/handler.js
+++ b/lib/m2node/handler.js
@@ -19,8 +19,14 @@
       this.pullSocket.on('message', __bind(function(message) {
         return this.emit('request', new MongrelRequest(message));
       }, this));
+      this.pullSocket.on('error', __bind(function(e) {
+        return this.emit('error', e);
+      }, this));
       this.pubSocket = zeromq.createSocket('pub');
       this.pubSocket.connect(options.send_spec);
+      this.pubSocket.on('error', __bind(function(e) {
+        return this.emit('error', e);
+      }, this));
     }
     Handler.prototype.sendResponse = function(request, response) {
       var header, outBuffer;

--- a/lib/m2node/handler.js
+++ b/lib/m2node/handler.js
@@ -9,7 +9,7 @@
     return child;
   }, __bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
   events = require('events');
-  zeromq = require('zeromq');
+  zeromq = require('zmq');
   MongrelRequest = require('./mongrel_request').MongrelRequest;
   Handler = (function() {
     __extends(Handler, events.EventEmitter);

--- a/package.json
+++ b/package.json
@@ -9,10 +9,9 @@
     [ "Paul Bergeron <paul.d.bergeron@gmail.com>" ],
   "main"                : "./lib/m2node.js",
   "repository"          : { "type": "git", "url" : "https://github.com/dan-manges/m2node.git" },
-  "engines"             : { "node": "~0.4.8" },
   "bundledDependencies" : [ "" ],
   "dependencies" : {
-    "zmq": "1.0.2"
+    "zmq": "git+ssh://git@github.com:dinedal/zeromq.node.git"
   },
   "devDependencies" : {
     "coffee-script": "~1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "repository"          : { "type": "git", "url" : "https://github.com/dan-manges/m2node.git" },
   "bundledDependencies" : [ "" ],
   "dependencies" : {
-    "zmq": "git+ssh://git@github.com:dinedal/zeromq.node.git"
+    "zmq": "1.0.4"
   },
   "devDependencies" : {
     "coffee-script": "~1.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engines"             : { "node": "~0.4.8" },
   "bundledDependencies" : [ "" ],
   "dependencies" : {
-    "zeromq": "~0.5.1"
+    "zmq": "1.0.2"
   },
   "devDependencies" : {
     "coffee-script": "~1.1",

--- a/src/m2node.coffee
+++ b/src/m2node.coffee
@@ -9,6 +9,7 @@ exports.run = (server, options) ->
     fakeSocket = new FakeSocket()
     fakeSocket.on 'write', ->
       handler.sendResponse(request, fakeSocket.writeBuffer)
+      handler.emit 'response'
     server.emit 'connection', fakeSocket
     fakeSocket.emitData(request.toFullHttpRequest())
   handler

--- a/src/m2node/handler.coffee
+++ b/src/m2node/handler.coffee
@@ -1,5 +1,5 @@
 events = require 'events'
-zeromq = require 'zeromq'
+zeromq = require 'zmq'
 
 {MongrelRequest} = require './mongrel_request'
 

--- a/src/m2node/handler.coffee
+++ b/src/m2node/handler.coffee
@@ -9,9 +9,12 @@ class Handler extends events.EventEmitter
     @pullSocket.connect(options.recv_spec)
     @pullSocket.on 'message', (message) =>
       @emit 'request', new MongrelRequest(message)
-
+    @pullSocket.on 'error', (e) =>
+      @emit 'error', e
     @pubSocket = zeromq.createSocket('pub')
     @pubSocket.connect(options.send_spec)
+    @pubSocket.on 'error', (e) =>
+      @emit 'error', e
 
   sendResponse: (request, response) ->
     header = [


### PR DESCRIPTION
Hi dan, made changes to the ZMQ sockets to emit any errors the get via the handle. This allows one to listen for any ZMQ error raised in one place regardless of socket. Please let me know if you have any questions.
