### PR TITLE
upgrade to zmq ~2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engines"             : { "node": "~0.8.0" },
   "bundledDependencies" : [ "" ],
   "dependencies" : {
-    "zmq": "~2.1.0"
+    "zmq": "~2.1.0 || ~2.2.0"
   },
   "devDependencies" : {
     "coffee-script": "~1.3.0",


### PR DESCRIPTION
this is a trivial one, but without this dependency I cannot npm install m2node
